### PR TITLE
Optimise build.sh (GCC) for Jaguar SoC

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ fi
 
 Msg "Building Time!!!"
 cd $clonedir
-make -j$cpu_num V=s
+make -j$cpu_num V=s -march=btver2 -mtune=btver2
 
 if [ $? -ne 0 ]; then
   cd - > /dev/null


### PR DESCRIPTION
GCC has its own target for the Jaguar SoCs. We can optimise by using the "-march=btver2 -mtune=btver2" GCC options, with a recent GCC version. See https://github.com/riptidewave93/LEDE-APU2/issues/3
